### PR TITLE
Fix peerDependencies of `flow-bin` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "should": "~10.0.0"
   },
   "peerDependencies": {
-    "flow-bin": "^0.39.0"
+    "flow-bin": ">=0.39.0 <1.0"
   },
   "engines": {
     "node": ">=4.0",


### PR DESCRIPTION
`SemVer` behaviour is different in case major version of package is 0 (it's considered to be a pre-release version) so `^0.39.0` only corresponds to '0.39.0', which limits you from using any newer version of `flow-bin`. Required version is changed to allow all newer version up to `1.0`.